### PR TITLE
Changes from background agent bc-662bee00-cb99-426c-88c8-d05fdf1d9af7

### DIFF
--- a/custom_weapons.sp
+++ b/custom_weapons.sp
@@ -1858,7 +1858,7 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 							}
 							KvGoBack(hKv);
 						}
-						new bool:b_flip_model = bool:KvGetNum(hKv, "flip_view_model", false);
+						new bool:b_flip_model = bool:KvGetNum(hKv, "flip_view_model", true);
 						
 						if (IsValidEdict(ClientVM2[client]))
 						{
@@ -1872,12 +1872,17 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 								SetEntProp(WeaponIndex, Prop_Send, "m_nSkin", skin_index);
 							}
 							
-							if (b_flip_model)
+							if (!b_flip_model)
 							{
+								// For left-handed models, use knife slot to flip orientation
 								new weapon = GetPlayerWeaponSlot(client, 2);
 								if (weapon != -1)
 								{
 									CSViewModel_SetWeapon(ClientVM2[client], weapon);
+								}
+								else
+								{
+									CSViewModel_SetWeapon(ClientVM2[client], WeaponIndex);
 								}
 							}
 							else
@@ -2098,18 +2103,22 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 						}
 						KvGoBack(hKv);
 					}
-					new bool:b_flip_model = bool:KvGetNum(hKv, "flip_view_model", false);
+					new bool:b_flip_model = bool:KvGetNum(hKv, "flip_view_model", true);
 					
 					if (!IsCustom[client])
 					{
 						iPrevIndex[client] = CSViewModel_GetModelIndex(ClientVM[client]);
 					}
-					if (b_flip_model)
+					// Default weapon assignment
+					CSViewModel_SetWeapon(ClientVM[client], WeaponIndex);
+					
+					if (!b_flip_model)
 					{
+						// For left-handed models, use knife slot to flip orientation
 						new weapon = GetPlayerWeaponSlot(client, 2);
 						if (weapon != -1)
 						{
-							CSViewModel_SetWeapon(ClientVM[client], WeaponIndex);
+							CSViewModel_SetWeapon(ClientVM[client], weapon);
 						}
 					}
 					SetEntProp(WeaponIndex, Prop_Send, "m_nModelIndex", 0);


### PR DESCRIPTION
Fixes custom weapons appearing in the left hand.

The `flip_view_model` logic was inverted, causing most custom weapon models to display incorrectly (left-handed) by default. This PR corrects the logic and sets the default `flip_view_model` to `true` for proper right-handed display.

---
<a href="https://cursor.com/background-agent?bcId=bc-662bee00-cb99-426c-88c8-d05fdf1d9af7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-662bee00-cb99-426c-88c8-d05fdf1d9af7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>